### PR TITLE
Add Passafari to list of Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ Additions and improvements are welcome! Please make pull-requests.
 * **[pidgin-zx2c4-pass](https://github.com/denimor/pidgin-zx2c4-pass)**: Plugin that allows to use zx2c4 pass to store passwords (for [pidgin](https://pidgin.im/)).
 * **[tmux-pass](https://github.com/rafi/tmux-pass)**: Quick password-store browser with preview using fzf in tmux.
 * **[vim-password-store](https://github.com/fourjay/vim-password-store)**: Vim niceties for password store.
+* **[Passafari](https://github.com/adur1990/Passafari)** Safari app extension for pass.


### PR DESCRIPTION
I wrote Passafari, a Safari app extension for pass. Would be nice, if it is included to this awesome list.