### PR TITLE
Update browserpass to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Additions and improvements are welcome! Please make pull-requests.
 ## Interfaces
 
 * **[Android-Password-Store](https://github.com/zeapo/Android-Password-Store)**: Android application compatible with ZX2C4's Pass command line application.
-* **[browserpass](https://github.com/browserpass/browserpass)**: Chrome & Firefox browser extension for pass.
+* **[browserpass](https://github.com/browserpass/browserpass-extension)**: Chrome & Firefox browser extension for pass.
 * **[gnome-pass-search-provider](https://github.com/jle64/gnome-pass-search-provider)**: Pass password manager search provider for gnome-shell.
 * **[gopass-tui](https://github.com/leitzler/gopass-tui)**: Terminal UI for pass/gopass.
 * **[krunner-pass](https://github.com/akermu/krunner-pass)**: Integrates krunner (KDE) with pass.


### PR DESCRIPTION
Old repo was archived and moved to a new address.