### PR TITLE
Replace Passafari with Pass for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Additions and improvements are welcome! Please make pull-requests.
 * **[pass-companion](https://github.com/kakolisgay/pass-companion)**: Chrome/Chromium browser extension for pass.
 * **[pass-zsh-completion](https://github.com/ninrod/pass-zsh-completion)**: pass zsh completion plugin.
 * **[pass.applescript](https://git.zx2c4.com/password-store/tree/contrib/pass.applescript)**: OS X integration
-* **[Passafari](https://github.com/adur1990/Passafari)** Safari app extension for pass.
+* **[Pass for macOS](https://github.com/adur1990/Pass-for-macOS)** macOS wrapper and Safari extension.
 * **[passff](https://github.com/passff/passff)**: zx2c4 pass manager extension for Firefox, Chrome and Opera.
 * **[passforios](https://github.com/mssun/passforios)**: Pass for iOS - an iOS client compatible with Pass command line application.
 * **[PassHUD](https://github.com/mnussbaum/PassHUD)**: A HUD-style interface for pass on macOS.


### PR DESCRIPTION
Passafari was extended by a macOS status bar app, resulting in renaming the app to Pass for macOS.