### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Additions and improvements are welcome! Please make pull-requests.
 * **[prs](https://github.com/timvisee/prs)**: A multi-platform pass client in Rust supporting sync, TOTP, Tombs and more.
 * **[qtpass](https://qtpass.org/)**: QtPass is a multi-platform GUI.
 * **[ripasso](https://github.com/cortex/ripasso)**: A simple password manager written in Rust.
-* **[rofi-pass](https://github.com/carnager/rofi-pass)**: A bash script to handle Simple Password Store in a convenient way using rofi.
+* **[rofi-pass](https://git.sr.ht/~mcepl/rofi-pass)**: A bash script to handle Simple Password Store in a convenient way using rofi.
 * **[tessen](https://sr.ht/~ayushnix/tessen)**: an interactive menu to autotype and copy pass and gopass data
 * **[tmux-pass](https://github.com/rafi/tmux-pass)**: Quick password-store browser with preview using fzf in tmux.
 * **[upass](https://github.com/Kwpolska/upass)**: Console UI for pass.


### PR DESCRIPTION
rofi-pass on https://github.com/carnager/rofi-pass.git was in fact abandoned, and the development continues in my repo https://git.sr.ht/~mcepl/rofi-pass

# Description

Fix the address of `rofi-pass`

# Checklist

- [x] I made sure to keep the list in alphabetical order
